### PR TITLE
👷 Create backend-dev.yml

### DIFF
--- a/.github/workflows/backend-dev.yml
+++ b/.github/workflows/backend-dev.yml
@@ -1,0 +1,81 @@
+name: backend
+
+on:
+  pull_request:
+    paths:
+      - backend/**
+      - .github/workflows/backend.yml
+    branches: [ "main" ]
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        service: [ inventoryservice, qrservice, reservationservice, mailservice ]
+        include:
+          - service: inventoryservice
+            webhook_var: PORTAINER_INVENTORYSERVICE_WEBHOOK_URL
+          - service: qrservice
+            webhook_var: PORTAINER_QRSERVICE_WEBHOOK_URL
+          - service: reservationservice
+            webhook_var: PORTAINER_RESERVATIONSERVICE_WEBHOOK_URL
+          - service: mailservice
+            webhook_var: PORTAINER_MAILSERVICE_WEBHOOK_URL
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Install QEMU for cross-platform builds
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check for changes in the service
+        id: changes
+        uses: tj-actions/changed-files@v45
+        with:
+          files: backend/${{ matrix.service }}/**
+
+      - name: Set execute permission for mvnw
+        if: steps.changes.outputs.any_modified == 'true'
+        working-directory: backend/${{ matrix.service }}/
+        run: chmod +x ./mvnw
+
+      - name: Build the Maven artifact
+        if: steps.changes.outputs.any_modified == 'true'
+        working-directory: backend/${{ matrix.service }}/
+        run: ./mvnw package -Pprod -DskipTests
+
+      - name: Build and push
+        if: steps.changes.outputs.any_modified == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: backend/${{ matrix.service }}/
+          file: backend/${{ matrix.service }}/src/main/docker/Dockerfile.jvm
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ghcr.io/thiws24/${{ matrix.service }}:dev
+
+      - name: Call a webhook for Portainer
+        if: steps.changes.outputs.any_modified == 'true'
+        uses: distributhor/workflow-webhook@v3
+        with:
+          webhook_type: 'json'
+          webhook_url: ${{ secrets[matrix.webhook_var] }}

--- a/.github/workflows/backend-dev.yml
+++ b/.github/workflows/backend-dev.yml
@@ -72,10 +72,3 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ghcr.io/thiws24/${{ matrix.service }}:dev
-
-      - name: Call a webhook for Portainer
-        if: steps.changes.outputs.any_modified == 'true'
-        uses: distributhor/workflow-webhook@v3
-        with:
-          webhook_type: 'json'
-          webhook_url: ${{ secrets[matrix.webhook_var] }}


### PR DESCRIPTION
Mir ist gerade aufgefallen, dass die Backend Services erst durch die CI beim push auf main gebaut werden. Aus diesem Grund möchte ich eine Abwandlung des Workflow-Files erstellen, welcher bereits bei einem PR die Services baut, damit man diese schon mal probeweise deployen kann.